### PR TITLE
Fixed broken link to micro-services plugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ example for a fully commented walk through of the example.
    * [simple-plugin](//github.com/rjrodger/seneca-examples/tree/master/simple-plugin): Create a simple Seneca plugin, including unit tests.
    * [api-server](//github.com/rjrodger/seneca-examples/tree/master/api-server): building a REST server with Seneca
    * [plugin-web](//github.com/rjrodger/seneca-examples/tree/master/plugin-web): creating plugins that expose web user interfaces
-   * [micro-services](github.com/rjrodger/seneca-examples/tree/master/micro-services): create a small micro-services system
+   * [micro-services](//github.com/rjrodger/seneca-examples/tree/master/micro-services): create a small micro-services system
    * [user-accounts](//github.com/rjrodger/seneca-examples/tree/master/user-accounts): A user account system, showing login/logout logic.
    * [shopping-cart](//github.com/rjrodger/seneca-examples/tree/master/shopping-cart): A shopping cart example, showing how plugins expose additional HTTP APIs.
 


### PR DESCRIPTION
The link was missing the // at the beginning, so clicking it was redirecting to "https://github.com/rjrodger/seneca-examples/blob/master/github.com/rjrodger/seneca-examples/tree/master/micro-services" ...rather than "https://github.com/rjrodger/seneca-examples/tree/master/micro-services". The link now works (after my small change).
