### PR TITLE
Update "data entities example" to support Seneca 3.X

### DIFF
--- a/data-entities/README.md
+++ b/data-entities/README.md
@@ -26,6 +26,8 @@ to do this, as it exposes the underlying database API.
 Setup:
 $ npm install
 
+Create folders bar-data, foo-data, zed-data.
+
 Note: seneca-level-store compiles the level modules, as they are
 native.  If this does not work on your platform (e.g. Windows), just
 comment out the level-store code.

--- a/data-entities/main.js
+++ b/data-entities/main.js
@@ -6,6 +6,8 @@ var util = require('util')
 
 var seneca = require('seneca')()
 
+seneca.use('basic')
+seneca.use('entity')
 // Use two separate instances of jsonfile-store, each looking after a 
 // different set of data entities
 seneca.use( 'jsonfile-store$foo', { folder:'foo-data', map:{'-/foo/-':'*'}})

--- a/data-entities/package.json
+++ b/data-entities/package.json
@@ -9,7 +9,9 @@
   "license": "MIT",
   "dependencies": {
     "seneca": "plugin",
-    "seneca-level-store": "~0.2.1",
-    "seneca-jsonfile-store": "~0.2.2"
+    "seneca-basic": "^0.5.0",
+    "seneca-entity": "^1.3.0",
+    "seneca-jsonfile-store": "^0.2.2",
+    "seneca-level-store": "^0.2.3"
   }
 }


### PR DESCRIPTION
Update "data entities example" to support Seneca 3.X
